### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Eri-py/Hobbyist/security/code-scanning/2](https://github.com/Eri-py/Hobbyist/security/code-scanning/2)

The best way to fix this issue is to explicitly add a `permissions` block to the workflow, restricting the GitHub Actions jobs to the minimum permissions necessary. If the job only needs to read repository contents (which is sufficient for checkouts and read-only testing), then set:
```yaml
permissions:
  contents: read
```
This block can be added either at the root of the workflow (e.g. after the `name:` and before `on:`), or directly to individual jobs—putting it at the root will apply it to all jobs unless overridden. Given the current workflow structure, add `permissions:` at the root level, after the workflow name and before the `on` block—that would be right after line 4.

No additional imports or packages are needed. Simply insert the block (two lines) as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
