### PR TITLE
create logic bug fixes

### DIFF
--- a/Mobile/src/app/(create)/index.tsx
+++ b/Mobile/src/app/(create)/index.tsx
@@ -48,11 +48,10 @@ export default function CreateScreen() {
         ) : (
           <Stack.Toolbar.Button
             variant="done"
+            icon="checkmark"
             onPress={handleSubmit}
             disabled={isSubmitting || isCreatingDraft}
-          >
-            Post
-          </Stack.Toolbar.Button>
+          />
         )}
       </Stack.Toolbar>
 

--- a/Mobile/src/hooks/create/useCreate.ts
+++ b/Mobile/src/hooks/create/useCreate.ts
@@ -94,11 +94,9 @@ export function useCreate() {
 
   // --- Draft state ---
 
-  const [draftPostId, setDraftPostId] = useState<string | null>(null);
   // Ref so handleBack and handleSubmit always read the latest ID without
   // needing it in their dependency arrays.
   const draftPostIdRef = useRef<string | null>(null);
-  draftPostIdRef.current = draftPostId;
 
   // --- Queries ---
 
@@ -129,9 +127,7 @@ export function useCreate() {
       return createDraftApi(formData);
     },
     onSuccess: (response) => {
-      const postId = response.data.postId;
-      setDraftPostId(postId);
-      draftPostIdRef.current = postId;
+      draftPostIdRef.current = response.data.postId;
     },
     onError: (error: ServerError) => handleServerError(error),
   });
@@ -146,7 +142,6 @@ export function useCreate() {
   const discardDraftMutation = useMutation({
     mutationFn: (postId: string) => discardDraftApi(postId),
     onSuccess: () => {
-      setDraftPostId(null);
       draftPostIdRef.current = null;
     },
     // Discard is best-effort — a failed discard is logged but not surfaced to the user
@@ -202,7 +197,7 @@ export function useCreate() {
     // Submit
     handleSubmit,
     isSubmitting: publishPostMutation.isPending,
-    // Upload (processing + network) — used to disable the Next button
+    // Upload (processing + network) — used to disable the Post button while media is still uploading
     isCreatingDraft: createDraftMutation.isPending,
     // Errors
     serverErrorMessage,

--- a/Mobile/src/hooks/create/useMediaPicker.ts
+++ b/Mobile/src/hooks/create/useMediaPicker.ts
@@ -68,7 +68,10 @@ export function useMediaPicker() {
         return;
       }
 
-      if (selectedAssets.length >= MAX_FILES) return;
+      if (selectedAssets.length >= MAX_FILES) {
+        setMediaError(`You can select up to ${MAX_FILES} files.`);
+        return;
+      }
 
       const info = await MediaLibrary.getAssetInfoAsync(asset);
       const uri = info.localUri ?? info.uri;

--- a/WebServer/.editorconfig
+++ b/WebServer/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.cs]
+dotnet_diagnostic.IDE0005.severity = warning

--- a/WebServer/.editorconfig
+++ b/WebServer/.editorconfig
@@ -2,3 +2,6 @@ root = true
 
 [*.cs]
 dotnet_diagnostic.IDE0005.severity = warning
+
+[**/Migrations/**.cs]
+dotnet_diagnostic.IDE0005.severity = none

--- a/WebServer/Hobbyist.Api/Dtos/Posts/CreatePostDtos.cs
+++ b/WebServer/Hobbyist.Api/Dtos/Posts/CreatePostDtos.cs
@@ -5,20 +5,21 @@ namespace Hobbyist.Api.Dtos.Posts;
 public record class CreatePostRequest
 {
     [Required]
-    [MaxLength(100)]
+    [MaxLength(50)]
     public required string Hobby { get; set; }
 
     [Required]
-    [MaxLength(150)]
+    [MaxLength(100)]
     public required string Title { get; set; }
 
     [Required]
-    [MaxLength(5000)]
+    [MinLength(10)]
+    [MaxLength(2000)]
     public required string Description { get; set; }
 
     public required bool AvailableForTrade { get; set; }
 
-    [MaxLength(150)]
+    [MaxLength(500)]
     public string? LookingFor { get; set; }
 
     [Required]

--- a/WebServer/Hobbyist.Api/Dtos/Posts/PostDraftDtos.cs
+++ b/WebServer/Hobbyist.Api/Dtos/Posts/PostDraftDtos.cs
@@ -46,19 +46,20 @@ public record RemoveDraftMediaRequest
 public record PublishPostRequest
 {
     [Required]
-    [MaxLength(100)]
+    [MaxLength(50)]
     public required string Hobby { get; set; }
 
     [Required]
-    [MaxLength(150)]
+    [MaxLength(100)]
     public required string Title { get; set; }
 
     [Required]
-    [MaxLength(5000)]
+    [MinLength(10)]
+    [MaxLength(2000)]
     public required string Description { get; set; }
 
     public required bool AvailableForTrade { get; set; }
 
-    [MaxLength(150)]
+    [MaxLength(500)]
     public string? LookingFor { get; set; }
 }

--- a/WebServer/Hobbyist.Api/Extensions/ServiceRegistrations/InfrastructureServices/MediaStorageServiceRegistration.cs
+++ b/WebServer/Hobbyist.Api/Extensions/ServiceRegistrations/InfrastructureServices/MediaStorageServiceRegistration.cs
@@ -1,4 +1,3 @@
-using System;
 using Hobbyist.Api.Services.MediaStorageServices;
 
 namespace Hobbyist.Api.Extensions.ServiceRegistrations.InfrastructureServices;

--- a/WebServer/Hobbyist.Api/Hobbyist.Api.csproj
+++ b/WebServer/Hobbyist.Api/Hobbyist.Api.csproj
@@ -4,6 +4,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.23.3" />

--- a/WebServer/Hobbyist.Api/Hobbyist.Api.csproj
+++ b/WebServer/Hobbyist.Api/Hobbyist.Api.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.23.3" />

--- a/WebServer/Hobbyist.Api/Services/CacheServices/ICache.cs
+++ b/WebServer/Hobbyist.Api/Services/CacheServices/ICache.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Hobbyist.Api.Services.CacheServices;
 
 public interface ICache

--- a/WebServer/Hobbyist.Api/Services/CacheServices/MemoryCache.cs
+++ b/WebServer/Hobbyist.Api/Services/CacheServices/MemoryCache.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Hobbyist.Api.Services.CacheServices;

--- a/WebServer/Hobbyist.Api/Services/MediaStorageServices/MinIOMediaStorageService.cs
+++ b/WebServer/Hobbyist.Api/Services/MediaStorageServices/MinIOMediaStorageService.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Hobbyist.Api.Dtos;
@@ -89,7 +88,11 @@ public class MinIOMediaStorageService(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to delete media object with key '{ObjectKey}'", objectKey.SanitizeForLog());
+            logger.LogError(
+                ex,
+                "Failed to delete media object with key '{ObjectKey}'",
+                objectKey.SanitizeForLog()
+            );
             return Result.InternalServerError(ErrorMessages.UnexpectedError);
         }
     }
@@ -235,7 +238,11 @@ public class MinIOMediaStorageService(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to delete objects under prefix '{Prefix}'", prefix.SanitizeForLog());
+            logger.LogError(
+                ex,
+                "Failed to delete objects under prefix '{Prefix}'",
+                prefix.SanitizeForLog()
+            );
             return Result.InternalServerError(ErrorMessages.UnexpectedError);
         }
     }

--- a/WebServer/Hobbyist.Api/Services/PostServices/CreatePostServices/CreatePostService.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/CreatePostServices/CreatePostService.cs
@@ -2,11 +2,9 @@ using Hobbyist.Api.Data;
 using Hobbyist.Api.Data.Entities;
 using Hobbyist.Api.Dtos;
 using Hobbyist.Api.Dtos.Posts;
-using Hobbyist.Api.Extensions;
 using Hobbyist.Api.Services.MediaStorageServices;
 using Hobbyist.Common;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Hobbyist.Api.Services.PostServices.CreatePostServices;
 
@@ -22,11 +20,14 @@ public class CreatePostService(
         CancellationToken ct
     )
     {
-        if (request.Media.Length == 0)
-            return Result<CreatePostResponse>.BadRequest("At least one media file is required.");
+        var mediaError = PostHelpers.ValidateMedia(request.Media);
+        if (mediaError is not null)
+            return Result<CreatePostResponse>.BadRequest(mediaError);
 
-        if (request.Media.Any(file => file.Length <= 0))
-            return Result<CreatePostResponse>.BadRequest("Uploaded files must not be empty.");
+        if (request.AvailableForTrade && string.IsNullOrWhiteSpace(request.LookingFor))
+            return Result<CreatePostResponse>.BadRequest(
+                "Please describe what you're looking for."
+            );
 
         if (!Guid.TryParse(userId, out var userGuid))
             return Result<CreatePostResponse>.BadRequest("Invalid user identifier.");
@@ -52,7 +53,12 @@ public class CreatePostService(
         if (!postStoreResult.IsSuccess)
         {
             // Best-effort rollback to avoid orphaned media objects.
-            await CleanupUploadedMediaAsync(uploadedObjectKeys, ct);
+            await PostHelpers.CleanupUploadedObjectsAsync(
+                uploadedObjectKeys,
+                mediaStorageService,
+                logger,
+                ct
+            );
             return Result<CreatePostResponse>.FromError(postStoreResult);
         }
 
@@ -92,7 +98,12 @@ public class CreatePostService(
             if (!uploadResult.IsSuccess)
             {
                 // Upload failed mid-batch: cleanup anything that was already uploaded.
-                await CleanupUploadedMediaAsync(uploadedObjectKeys, ct);
+                await PostHelpers.CleanupUploadedObjectsAsync(
+                    uploadedObjectKeys,
+                    mediaStorageService,
+                    logger,
+                    ct
+                );
                 return uploadResult.ResultType switch
                 {
                     ResultTypes.BadRequest => Result.BadRequest(
@@ -160,40 +171,5 @@ public class CreatePostService(
         }
 
         return Result.NoContent();
-    }
-
-    private async Task CleanupUploadedMediaAsync(
-        IEnumerable<string> objectKeys,
-        CancellationToken ct
-    )
-    {
-        // Cleanup is best-effort: log and continue so one delete failure does not block others.
-        foreach (var objectKey in objectKeys)
-        {
-            try
-            {
-                var deleteResult = await mediaStorageService.DeleteAsync(objectKey, ct);
-                if (!deleteResult.IsSuccess)
-                {
-                    logger.LogWarning(
-                        "Failed to rollback uploaded media object '{ObjectKey}'. ResultType: {ResultType}",
-                        objectKey.SanitizeForLog(),
-                        deleteResult.ResultType
-                    );
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(
-                    ex,
-                    "Unexpected error while rolling back uploaded media object '{ObjectKey}'",
-                    objectKey.SanitizeForLog()
-                );
-            }
-        }
     }
 }

--- a/WebServer/Hobbyist.Api/Services/PostServices/PostDraftServices/IPostDraftService.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/PostDraftServices/IPostDraftService.cs
@@ -1,6 +1,5 @@
 using Hobbyist.Api.Dtos.Posts;
 using Hobbyist.Common;
-using Microsoft.AspNetCore.Http;
 
 namespace Hobbyist.Api.Services.PostServices.PostDraftServices;
 

--- a/WebServer/Hobbyist.Api/Services/PostServices/PostDraftServices/PostDraftService.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/PostDraftServices/PostDraftService.cs
@@ -2,10 +2,8 @@ using Hobbyist.Api.Data;
 using Hobbyist.Api.Data.Entities;
 using Hobbyist.Api.Dtos;
 using Hobbyist.Api.Dtos.Posts;
-using Hobbyist.Api.Extensions;
 using Hobbyist.Api.Services.MediaStorageServices;
 using Hobbyist.Common;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
 namespace Hobbyist.Api.Services.PostServices.PostDraftServices;
@@ -23,19 +21,12 @@ public class PostDraftService(
         CancellationToken ct
     )
     {
-        if (media.Length == 0)
-            return Result<CreateDraftResponse>.BadRequest("At least one media file is required.");
-
-        if (media.Any(f => f.Length <= 0))
-            return Result<CreateDraftResponse>.BadRequest("Uploaded files must not be empty.");
+        var mediaError = PostHelpers.ValidateMedia(media);
+        if (mediaError is not null)
+            return Result<CreateDraftResponse>.BadRequest(mediaError);
 
         if (!Guid.TryParse(userId, out var userGuid))
             return Result<CreateDraftResponse>.BadRequest("Invalid user identifier.");
-
-        if (media.Length > PostDraftConfig.MaxMediaFiles)
-            return Result<CreateDraftResponse>.BadRequest(
-                $"A post can contain at most {PostDraftConfig.MaxMediaFiles} media files."
-            );
 
         // Generate the post slug upfront so every object key is scoped to this draft.
         var postId = SlugGenerator.Generate();
@@ -68,7 +59,12 @@ public class PostDraftService(
 
             if (!uploadResult.IsSuccess)
             {
-                await CleanupUploadedObjectsAsync(uploadedKeys, ct);
+                await PostHelpers.CleanupUploadedObjectsAsync(
+                    uploadedKeys,
+                    mediaStorageService,
+                    logger,
+                    ct
+                );
                 return Result<CreateDraftResponse>.FromError(uploadResult);
             }
 
@@ -101,7 +97,12 @@ public class PostDraftService(
                 postId,
                 userId
             );
-            await CleanupUploadedObjectsAsync(uploadedKeys, ct);
+            await PostHelpers.CleanupUploadedObjectsAsync(
+                uploadedKeys,
+                mediaStorageService,
+                logger,
+                ct
+            );
             return Result<CreateDraftResponse>.InternalServerError(ErrorMessages.UnexpectedError);
         }
 
@@ -219,7 +220,7 @@ public class PostDraftService(
         if (!deleteResult.IsSuccess)
             return deleteResult;
 
-        post.MediaCount = Math.Max(0, post.MediaCount - 1);
+        post.MediaCount--;
 
         try
         {
@@ -263,6 +264,11 @@ public class PostDraftService(
         if (post.MediaCount == 0)
             return Result<CreatePostResponse>.BadRequest(
                 "At least one media file is required before publishing."
+            );
+
+        if (request.AvailableForTrade && string.IsNullOrWhiteSpace(request.LookingFor))
+            return Result<CreatePostResponse>.BadRequest(
+                "Please describe what you're looking for."
             );
 
         post.Hobby = request.Hobby;
@@ -324,49 +330,10 @@ public class PostDraftService(
         }
         catch (Exception ex)
         {
-            logger.LogError(
-                ex,
-                "Failed to remove draft post {PostId} from database",
-                postId
-            );
+            logger.LogError(ex, "Failed to remove draft post {PostId} from database", postId);
             return Result.InternalServerError(ErrorMessages.UnexpectedError);
         }
 
         return Result.NoContent();
-    }
-
-    // -------------------------------------------------------------------------
-    // Private helpers
-    // -------------------------------------------------------------------------
-
-    private async Task CleanupUploadedObjectsAsync(
-        IEnumerable<string> objectKeys,
-        CancellationToken ct
-    )
-    {
-        foreach (var key in objectKeys)
-        {
-            try
-            {
-                var result = await mediaStorageService.DeleteAsync(key, ct);
-                if (!result.IsSuccess)
-                    logger.LogWarning(
-                        "Rollback: failed to delete uploaded object '{ObjectKey}'",
-                        key.SanitizeForLog()
-                    );
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(
-                    ex,
-                    "Rollback: unexpected error deleting object '{ObjectKey}'",
-                    key.SanitizeForLog()
-                );
-            }
-        }
     }
 }

--- a/WebServer/Hobbyist.Api/Services/PostServices/PostHelpers.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/PostHelpers.cs
@@ -1,0 +1,55 @@
+using Hobbyist.Api.Extensions;
+using Hobbyist.Api.Services.MediaStorageServices;
+using Hobbyist.Api.Services.PostServices.PostDraftServices;
+
+namespace Hobbyist.Api.Services.PostServices;
+
+internal static class PostHelpers
+{
+    internal static string? ValidateMedia(IFormFile[] media)
+    {
+        if (media.Length == 0)
+            return "At least one media file is required.";
+
+        if (media.Any(f => f.Length <= 0))
+            return "Uploaded files must not be empty.";
+
+        if (media.Length > PostDraftConfig.MaxMediaFiles)
+            return $"A post can contain at most {PostDraftConfig.MaxMediaFiles} media files.";
+
+        return null;
+    }
+
+    internal static async Task CleanupUploadedObjectsAsync(
+        IEnumerable<string> objectKeys,
+        IMediaStorageService mediaStorageService,
+        ILogger logger,
+        CancellationToken ct
+    )
+    {
+        foreach (var key in objectKeys)
+        {
+            try
+            {
+                var result = await mediaStorageService.DeleteAsync(key, ct);
+                if (!result.IsSuccess)
+                    logger.LogWarning(
+                        "Rollback: failed to delete uploaded object '{ObjectKey}'",
+                        key.SanitizeForLog()
+                    );
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Rollback: unexpected error deleting object '{ObjectKey}'",
+                    key.SanitizeForLog()
+                );
+            }
+        }
+    }
+}

--- a/WebServer/Hobbyist.Api/Services/PostServices/PostMediaValidation.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/PostMediaValidation.cs
@@ -1,0 +1,2 @@
+// Moved to PostHelpers.cs
+namespace Hobbyist.Api.Services.PostServices;

--- a/Website/src/components/shared/ErrorStack.tsx
+++ b/Website/src/components/shared/ErrorStack.tsx
@@ -14,11 +14,19 @@ type ErrorStackPosition =
 type ErrorStackProps = {
   errors: MediaUploadError[];
   onRemoveError: (errorId: string) => void;
+  serverError?: string | null;
+  onClearServerError?: () => void;
   position?: ErrorStackPosition;
 };
 
-export function ErrorStack({ errors, onRemoveError, position = "top-right" }: ErrorStackProps) {
-  if (errors.length === 0) return null;
+export function ErrorStack({
+  errors,
+  onRemoveError,
+  serverError,
+  onClearServerError,
+  position = "top-right",
+}: ErrorStackProps) {
+  if (errors.length === 0 && !serverError) return null;
 
   const isTop = position.startsWith("top");
   const verticalPlacement = isTop ? { top: 70 } : { top: "calc(100% - 60px)" };
@@ -44,6 +52,23 @@ export function ErrorStack({ errors, onRemoveError, position = "top-right" }: Er
         maxWidth: 370,
       }}
     >
+      {serverError && (
+        <Alert
+          severity="error"
+          action={
+            <IconButton
+              size="small"
+              color="inherit"
+              onClick={onClearServerError}
+              sx={{ ml: 1 }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          }
+        >
+          {serverError}
+        </Alert>
+      )}
       {errors.map((error) => (
         <Alert
           key={error.id}

--- a/Website/src/routes/_app/create.tsx
+++ b/Website/src/routes/_app/create.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { FormProvider } from "react-hook-form";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect } from "react";
 import type { KeyboardEvent } from "react";
 
 import Stack from "@mui/material/Stack";
@@ -13,7 +13,6 @@ import { DesktopCreateForm } from "@/components/create/desktop/DesktopCreateForm
 import { MobileCreateForm } from "@/components/create/mobile/MobileCreateForm";
 import { useAuth } from "@hobbyist/hooks";
 
-const SERVER_ERROR_ID = "create-server-error";
 
 export const Route = createFileRoute("/_app/create")({
   component: CreatePage,
@@ -72,23 +71,11 @@ function CreatePage() {
     clearFiles,
   } = useMediaUpload({ onFilesAdded, onFileRemoved });
 
-  const allErrors = useMemo(() => {
-    if (serverErrorMessage) {
-      return [...errors, { id: SERVER_ERROR_ID, message: serverErrorMessage }];
-    }
-    return errors;
-  }, [errors, serverErrorMessage]);
-
-  const handleRemoveError = (errorId: string) => {
-    if (errorId === SERVER_ERROR_ID) return clearServerError();
-    removeError(errorId);
-  };
-
   const handleClear = () => {
+    discardDraft();
     methods.reset();
     clearFiles();
     clearServerError();
-    discardDraft();
   };
 
   const preventEnterSubmit = (event: KeyboardEvent<HTMLFormElement>) => {
@@ -135,8 +122,10 @@ function CreatePage() {
           )}
 
           <ErrorStack
-            errors={allErrors}
-            onRemoveError={handleRemoveError}
+            errors={errors}
+            onRemoveError={removeError}
+            serverError={serverErrorMessage}
+            onClearServerError={clearServerError}
             position={isDesktop ? "top-right" : "bottom-center"}
           />
 


### PR DESCRIPTION
- Fix LookingFor MaxLength mismatch between frontend schema (500) and…backend DTOs (150), which caused valid client input to be rejected with a 400.
- Align Hobby, Title, and Description MaxLength values in both backend DTOs to match the shared Zod schema.
- Add [MinLength(10)] to Description in both DTOs to enforce the same minimum length the schema already requires.
- Add server-side conditional validation so LookingFor is required when AvailableForTrade is true, in both PublishDraftAsync and CreatePostAsync.
- Add missing max media file count check to CreatePostService, which PostDraftService already had. -Extract shared media validation into PostHelpers.ValidateMedia and shared S3 rollback logic have been moved into PostHelpers.CleanupUploadedObjectsAsync, removing the duplicate private methods from both services. -Replace Math.Max(0, post.MediaCount - 1) with post.MediaCount-- in RemoveMediaAsync since the guard was redundant given the preceding ownership checks.
- Add a user-facing error message when the max file limit is hit in the mobile media picker, replacing the previous silent return.
- Fix handleClear on the website to call discardDraft before resetting the form, preventing the draft from surviving a clear if the network call fails.
- Remove the SERVER_ERROR_ID workaround from create.tsx by adding serverError and onClearServerError props directly to ErrorStack.
- Remove redundant draftPostId useState from mobile useCreate, keeping only the ref to avoid the manual per-render sync.
- Replace the labeled Post button with a checkmark icon using the done variant for the blue tint. Add .editorconfig with IDE0005 set to warn, and enable EnforceCodeStyleInBuild to surface unused imports during dotnet build.