### PR TITLE
create bug fixes

### DIFF
--- a/Mobile/src/hooks/create/useCreate.ts
+++ b/Mobile/src/hooks/create/useCreate.ts
@@ -1,5 +1,5 @@
-import { createContext, useCallback, useContext, useState } from "react";
 import { Alert } from "react-native";
+import { createContext, useCallback, useContext, useState } from "react";
 import * as MediaLibrary from "expo-media-library";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
@@ -149,11 +149,7 @@ export function useCreate() {
 
                 await saveDraftApi(formData);
               } catch {
-                Alert.alert(
-                  "Couldn't save draft",
-                  "Something went wrong saving your draft.",
-                  [{ text: "OK" }],
-                );
+                // silent — best-effort draft save
               }
             })();
           },
@@ -191,11 +187,7 @@ export function useCreate() {
 
         await createPostApi(formData);
       } catch {
-        Alert.alert(
-          "Couldn't post",
-          "Something went wrong while uploading your post. Please try again.",
-          [{ text: "OK" }],
-        );
+        // silent — user will notice the post isn't on their profile
       }
     })();
   });

--- a/Mobile/src/hooks/create/useMediaPicker.ts
+++ b/Mobile/src/hooks/create/useMediaPicker.ts
@@ -40,6 +40,12 @@ async function processAssetForUpload(asset: MediaLibrary.AssetInfo, index: numbe
     }
   }
   const image = await context.renderAsync();
+  // Preserve PNG format so transparency survives; compress everything else as JPEG.
+  const isPng = (asset.filename ?? "").toLowerCase().endsWith(".png");
+  if (isPng) {
+    const result = await image.saveAsync({ format: SaveFormat.PNG });
+    return { uri: result.uri, name: `media_${index}.png`, type: "image/png" };
+  }
   const result = await image.saveAsync({ compress: 0.8, format: SaveFormat.JPEG });
   return { uri: result.uri, name: `media_${index}.jpg`, type: "image/jpeg" };
 }
@@ -69,6 +75,7 @@ export function useMediaPicker() {
       const albums = await MediaLibrary.getAlbumsAsync({ includeSmartAlbums: true });
       const album = albums.find((a) => a.title === activeAlbum);
       if (!album) return;
+      // Loads up to 1000 assets — users with larger libraries won't see older items.
       const { assets } = await MediaLibrary.getAssetsAsync({
         mediaType: ["photo", "video"],
         sortBy: MediaLibrary.SortBy.creationTime,
@@ -100,7 +107,10 @@ export function useMediaPicker() {
       const uri = info.localUri ?? info.uri;
       const size = new File(uri).size;
 
-      if (size > MAX_FILE_SIZE) {
+      // Images are compressed before upload so skip the per-file check for them —
+      // a large raw photo will shrink significantly. Videos are not compressed, so enforce strictly.
+      const isVideo = asset.mediaType === MediaLibrary.MediaType.video;
+      if (isVideo && size > MAX_FILE_SIZE) {
         setMediaError(
           `"${asset.filename}" exceeds the ${MAX_FILE_SIZE / 1024 / 1024}MB per-file limit.`,
         );

--- a/Shared/form-schemas/src/CreateSchemas.ts
+++ b/Shared/form-schemas/src/CreateSchemas.ts
@@ -23,7 +23,7 @@ export const CreateFormSchema = z
       .min(10, "Description must be at least 10 characters")
       .max(2000, "Description must be less than 2000 characters"),
 
-    availableForTrade: z.boolean().optional(),
+    availableForTrade: z.boolean(),
 
     lookingFor: z.string().trim().max(500, "Must be less than 500 characters").optional(),
   })

--- a/WebServer/Hobbyist.Api/Dtos/Posts/CreatePostDtos.cs
+++ b/WebServer/Hobbyist.Api/Dtos/Posts/CreatePostDtos.cs
@@ -5,10 +5,12 @@ namespace Hobbyist.Api.Dtos.Posts;
 public record class CreatePostRequest
 {
     [Required]
+    [MinLength(2)]
     [MaxLength(50)]
     public required string Hobby { get; set; }
 
     [Required]
+    [MinLength(3)]
     [MaxLength(100)]
     public required string Title { get; set; }
 

--- a/WebServer/Hobbyist.Api/Services/PostServices/CreatePostServices/CreatePostService.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/CreatePostServices/CreatePostService.cs
@@ -4,7 +4,6 @@ using Hobbyist.Api.Dtos;
 using Hobbyist.Api.Dtos.Posts;
 using Hobbyist.Api.Services.MediaStorageServices;
 using Hobbyist.Common;
-using Microsoft.EntityFrameworkCore;
 
 namespace Hobbyist.Api.Services.PostServices.CreatePostServices;
 
@@ -159,7 +158,7 @@ public class CreatePostService(
         {
             await context.SaveChangesAsync(ct);
         }
-        catch (DbUpdateException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(
                 ex,

--- a/WebServer/Hobbyist.Api/Services/PostServices/CreatePostServices/ICreatePostService.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/CreatePostServices/ICreatePostService.cs
@@ -15,25 +15,4 @@ public interface ICreatePostService
         CancellationToken ct
     );
 
-    /// <summary>
-    /// Uploads all media files for a post while collecting uploaded object keys for rollback.
-    /// </summary>
-    Task<Result> StorePostMediaAsync(
-        IFormFile[] media,
-        string userId,
-        string postId,
-        ICollection<string> uploadedObjectKeys,
-        CancellationToken ct
-    );
-
-    /// <summary>
-    /// Persists post metadata to the database after media storage succeeds.
-    /// </summary>
-    Task<Result> StorePostDetailsAsync(
-        CreatePostRequest request,
-        Guid userId,
-        string postId,
-        DateTimeOffset createdAt,
-        CancellationToken ct
-    );
 }

--- a/WebServer/Hobbyist.Api/Services/PostServices/PostDraftServices/PostDraftConfig.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/PostDraftServices/PostDraftConfig.cs
@@ -15,4 +15,10 @@ public static class PostDraftConfig
     /// Must stay in sync with MAX_FILES on the mobile client.
     /// </summary>
     public const int MaxMediaFiles = 15;
+
+    /// <summary>Maximum size in bytes for a single media file (50 MB).</summary>
+    public const long MaxFileSizeBytes = 50L * 1024 * 1024;
+
+    /// <summary>Maximum combined size in bytes for all media files in one request (100 MB).</summary>
+    public const long MaxTotalSizeBytes = 100L * 1024 * 1024;
 }

--- a/WebServer/Hobbyist.Api/Services/PostServices/PostDraftServices/PostDraftService.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/PostDraftServices/PostDraftService.cs
@@ -89,7 +89,7 @@ public class PostDraftService(
         {
             await context.SaveChangesAsync(ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(
                 ex,
@@ -130,39 +130,18 @@ public class PostDraftService(
         if (!post.IsDraft)
             return Result<CreatePostResponse>.BadRequest("Post is already published.");
 
-        if (post.MediaCount == 0)
-            return Result<CreatePostResponse>.BadRequest(
-                "At least one media file is required before publishing."
-            );
-
-        if (string.IsNullOrWhiteSpace(post.Hobby))
-            return Result<CreatePostResponse>.BadRequest("Hobby is required before publishing.");
-
-        if (string.IsNullOrWhiteSpace(post.Title))
-            return Result<CreatePostResponse>.BadRequest("Title is required before publishing.");
-
-        if (string.IsNullOrWhiteSpace(post.Description))
-            return Result<CreatePostResponse>.BadRequest(
-                "Description is required before publishing."
-            );
-
-        if (post.Description.Trim().Length < 10)
-            return Result<CreatePostResponse>.BadRequest(
-                "Description must be at least 10 characters."
-            );
-
-        if (post.AvailableForTrade && string.IsNullOrWhiteSpace(post.LookingFor))
-            return Result<CreatePostResponse>.BadRequest(
-                "Please describe what you're looking for."
-            );
+        var publishError = PostHelpers.ValidateDraftForPublish(post);
+        if (publishError is not null)
+            return Result<CreatePostResponse>.BadRequest(publishError);
 
         post.IsDraft = false;
+        post.CreatedAt = DateTimeOffset.UtcNow;
 
         try
         {
             await context.SaveChangesAsync(ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Failed to publish draft post {PostId}", postId);
             return Result<CreatePostResponse>.InternalServerError(ErrorMessages.UnexpectedError);
@@ -206,7 +185,7 @@ public class PostDraftService(
         {
             await context.SaveChangesAsync(ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Failed to remove draft post {PostId} from database", postId);
             return Result.InternalServerError(ErrorMessages.UnexpectedError);

--- a/WebServer/Hobbyist.Api/Services/PostServices/PostHelpers.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/PostHelpers.cs
@@ -1,3 +1,4 @@
+using Hobbyist.Api.Data.Entities;
 using Hobbyist.Api.Extensions;
 using Hobbyist.Api.Services.MediaStorageServices;
 using Hobbyist.Api.Services.PostServices.PostDraftServices;
@@ -6,6 +7,29 @@ namespace Hobbyist.Api.Services.PostServices;
 
 internal static class PostHelpers
 {
+    internal static string? ValidateDraftForPublish(PostEntity post)
+    {
+        if (post.MediaCount == 0)
+            return "At least one media file is required before publishing.";
+
+        if (string.IsNullOrWhiteSpace(post.Hobby))
+            return "Hobby is required before publishing.";
+
+        if (string.IsNullOrWhiteSpace(post.Title))
+            return "Title is required before publishing.";
+
+        if (string.IsNullOrWhiteSpace(post.Description))
+            return "Description is required before publishing.";
+
+        if (post.Description.Trim().Length < 10)
+            return "Description must be at least 10 characters.";
+
+        if (post.AvailableForTrade && string.IsNullOrWhiteSpace(post.LookingFor))
+            return "Please describe what you're looking for.";
+
+        return null;
+    }
+
     internal static string? ValidateMedia(IFormFile[] media)
     {
         if (media.Length == 0)
@@ -16,6 +40,14 @@ internal static class PostHelpers
 
         if (media.Length > PostDraftConfig.MaxMediaFiles)
             return $"A post can contain at most {PostDraftConfig.MaxMediaFiles} media files.";
+
+        var oversized = media.FirstOrDefault(f => f.Length > PostDraftConfig.MaxFileSizeBytes);
+        if (oversized is not null)
+            return $"\"{oversized.FileName}\" exceeds the {PostDraftConfig.MaxFileSizeBytes / 1024 / 1024} MB per-file limit.";
+
+        var totalSize = media.Sum(f => f.Length);
+        if (totalSize > PostDraftConfig.MaxTotalSizeBytes)
+            return $"Total upload size exceeds the {PostDraftConfig.MaxTotalSizeBytes / 1024 / 1024} MB limit.";
 
         return null;
     }

--- a/WebServer/Hobbyist.Api/Services/PostServices/PostMediaValidation.cs
+++ b/WebServer/Hobbyist.Api/Services/PostServices/PostMediaValidation.cs
@@ -1,2 +1,0 @@
-// Moved to PostHelpers.cs
-namespace Hobbyist.Api.Services.PostServices;

--- a/Website/src/hooks/create/compressImage.ts
+++ b/Website/src/hooks/create/compressImage.ts
@@ -33,17 +33,21 @@ export const compressImage = (file: File): Promise<File> => {
       ctx.drawImage(img, 0, 0, width, height);
       URL.revokeObjectURL(img.src);
 
+      const isPng = file.type === "image/png";
+      const outputType = isPng ? "image/png" : "image/jpeg";
+      const baseName = file.name.replace(/\.[^.]+$/, "");
+      const outputName = `${baseName}.${isPng ? "png" : "jpg"}`;
+
       canvas.toBlob(
         (blob) => {
           if (!blob) {
             resolve(file);
             return;
           }
-          const baseName = file.name.replace(/\.[^.]+$/, "");
-          resolve(new File([blob], `${baseName}.jpg`, { type: "image/jpeg" }));
+          resolve(new File([blob], outputName, { type: outputType }));
         },
-        "image/jpeg",
-        JPEG_QUALITY,
+        outputType,
+        isPng ? undefined : JPEG_QUALITY,
       );
     };
 

--- a/Website/src/hooks/create/useCreate.ts
+++ b/Website/src/hooks/create/useCreate.ts
@@ -52,7 +52,7 @@ const MOBILE_STEP_COUNT = Object.keys(mobileStepFields).length;
 
 // --- Hook ---
 
-export function useCreate(onPostCreated: (postId: string) => void) {
+export function useCreate(onPostCreated: () => void) {
   const { serverErrorMessage, handleServerError, clearServerError } = useServerError();
 
   const methods = useForm<CreateFormSchemaTypes>({
@@ -65,13 +65,6 @@ export function useCreate(onPostCreated: (postId: string) => void) {
       availableForTrade: false,
       lookingFor: "",
     },
-  });
-
-  const createPostMutation = useMutation({
-    mutationFn: ({ files, values }: { files: File[]; values: CreateFormSchemaTypes }) =>
-      createPostApi(files, values),
-    onSuccess: (response) => onPostCreated(response.data.postId),
-    onError: (error: ServerError) => handleServerError(error),
   });
 
   const saveDraftMutation = useMutation({
@@ -115,14 +108,13 @@ export function useCreate(onPostCreated: (postId: string) => void) {
     files: FileWithMetadata[],
     onFilesError: (message: string) => void,
   ) => {
-    clearServerError();
-
     if (files.length === 0) {
       onFilesError("Please upload at least one image or video before continuing.");
       return;
     }
 
-    createPostMutation.mutate({ files: files.map((f) => f.file), values });
+    onPostCreated();
+    void createPostApi(files.map((f) => f.file), values);
   };
 
   // --- Draft save (called by navigation blocker dialog) ---
@@ -144,7 +136,6 @@ export function useCreate(onPostCreated: (postId: string) => void) {
     serverErrorMessage,
     clearServerError,
     handleSubmit,
-    isSubmitting: createPostMutation.isPending,
     saveDraft,
     isSavingDraft: saveDraftMutation.isPending,
   };

--- a/Website/src/hooks/create/useMediaUpload.ts
+++ b/Website/src/hooks/create/useMediaUpload.ts
@@ -50,55 +50,57 @@ export function useMediaUpload() {
 
   const onDrop = useCallback(
     async (acceptedFiles: File[]) => {
-      if (acceptedFiles.length > 0) {
-        // Keep track of the original order before sorting
-        const filesWithIndex = acceptedFiles.map((file, index) => ({ file, originalIndex: index }));
+      if (acceptedFiles.length === 0) return;
 
-        // Sort by size for processing
-        const sortedFiles = filesWithIndex.sort((a, b) => a.file.size - b.file.size);
+      const withIndex = acceptedFiles.map((file, i) => ({ file, i }));
+      // Sort smallest-first so we fit as many files as possible within the total limit.
+      const sorted = [...withIndex].sort((a, b) => a.file.size - b.file.size);
 
-        // Get current size and slot count of all files already stored.
-        let currentTotal = 0;
-        filesWithMetadata.forEach((f) => (currentTotal += f.file.size));
-        const availableSlots = MAX_FILES - filesWithMetadata.length;
+      const availableSlots = MAX_FILES - filesWithMetadata.length;
+      const candidates = sorted.slice(0, availableSlots);
+      const overflow = sorted.slice(availableSlots);
 
-        // Keep track of added files and rejected files.
-        const toAdd: { file: File; originalIndex: number }[] = [];
-        const rejected: string[] = [];
+      const rejected: string[] = overflow.map(
+        ({ file }) => `${file.name}: Maximum ${MAX_FILES} files allowed.`,
+      );
 
-        for (const { file, originalIndex } of sortedFiles) {
-          if (toAdd.length >= availableSlots) {
-            rejected.push(`${file.name}: Maximum ${MAX_FILES} files allowed.`);
-          } else if (currentTotal + file.size > MAX_TOTAL_SIZE) {
-            rejected.push(
-              `${file.name}: Not enough space (${(currentTotal / 1024 / 1024).toFixed(2)}MB of ${(MAX_TOTAL_SIZE / 1024 / 1024).toFixed(2)}MB used)`,
-            );
-          } else {
-            currentTotal += file.size;
-            toAdd.push({ file, originalIndex });
-          }
+      // Compress all candidates in parallel, then size-check against compressed sizes.
+      const compressed = await Promise.all(
+        candidates.map(async ({ file, i }) => ({
+          file: await compressImage(file),
+          originalName: file.name,
+          i,
+        })),
+      );
+      // Restore original drop order before the size check.
+      compressed.sort((a, b) => a.i - b.i);
+
+      let currentTotal = filesWithMetadata.reduce((sum, f) => sum + f.file.size, 0);
+      const accepted: (typeof compressed)[number][] = [];
+
+      for (const entry of compressed) {
+        if (currentTotal + entry.file.size > MAX_TOTAL_SIZE) {
+          rejected.push(
+            `${entry.originalName}: Not enough space (${(currentTotal / 1024 / 1024).toFixed(2)}MB of ${(MAX_TOTAL_SIZE / 1024 / 1024).toFixed(2)}MB used)`,
+          );
+        } else {
+          currentTotal += entry.file.size;
+          accepted.push(entry);
         }
+      }
 
-        // Sort toAdd back to original upload order
-        toAdd.sort((a, b) => a.originalIndex - b.originalIndex);
+      const newFilesWithMetadata: FileWithMetadata[] = await Promise.all(
+        accepted.map(async ({ file }) => ({
+          id: crypto.randomUUID(),
+          file,
+          preview: await generateThumbnail(file),
+        })),
+      );
 
-        // Compress images and generate thumbnails
-        const newFilesWithMetadata: FileWithMetadata[] = await Promise.all(
-          toAdd.map(async ({ file }) => {
-            const processedFile = await compressImage(file);
-            return {
-              id: crypto.randomUUID(),
-              file: processedFile,
-              preview: await generateThumbnail(processedFile),
-            };
-          }),
-        );
+      setFilesWithMetadata((prev) => [...prev, ...newFilesWithMetadata]);
 
-        setFilesWithMetadata((prev) => [...prev, ...newFilesWithMetadata]);
-
-        if (rejected.length > 0) {
-          setErrors((prev) => [...prev, ...rejected.map(createMediaUploadError)]);
-        }
+      if (rejected.length > 0) {
+        setErrors((prev) => [...prev, ...rejected.map(createMediaUploadError)]);
       }
     },
     [filesWithMetadata],

--- a/Website/src/routes/_app/create.tsx
+++ b/Website/src/routes/_app/create.tsx
@@ -33,23 +33,15 @@ function CreatePage() {
 
   const hasPostedRef = useRef(false);
 
-  const handlePostCreated = useCallback(
-    (postId: string) => {
-      hasPostedRef.current = true;
-      if (user?.username) {
-        navigate({ to: `/profile/${user.username}/${postId}` });
-        return;
-      }
-      navigate({ to: "/profile" });
-    },
-    [navigate, user],
-  );
+  const handlePostCreated = useCallback(() => {
+    hasPostedRef.current = true;
+    navigate({ to: user?.username ? `/profile/${user.username}` : "/profile" });
+  }, [navigate, user]);
 
   const {
     methods,
     serverErrorMessage,
     handleSubmit,
-    isSubmitting,
     activeStep,
     handleNext,
     handleBack,
@@ -73,7 +65,7 @@ function CreatePage() {
 
   // Block navigation when the user has files loaded but hasn't posted yet.
   const blocker = useBlocker({
-    shouldBlockFn: () => files.length > 0 && !isSubmitting && !hasPostedRef.current,
+    shouldBlockFn: () => files.length > 0 && !hasPostedRef.current,
     enableBeforeUnload: true,
     withResolver: true,
   });
@@ -132,7 +124,7 @@ function CreatePage() {
                 isDragActive={isDragActive}
                 removeFile={removeFile}
                 reorderFiles={reorderFiles}
-                isSubmitting={isSubmitting}
+                isSubmitting={false}
                 onClear={handleClear}
               />
             ) : (
@@ -141,7 +133,7 @@ function CreatePage() {
                 getRootProps={getRootProps}
                 isDragActive={isDragActive}
                 removeFile={removeFile}
-                isSubmitting={isSubmitting}
+                isSubmitting={false}
                 activeStep={activeStep}
                 onNext={() => handleNext(files, addError)}
                 onBack={handleBack}

--- a/Website/src/tests/create/useCreate.test.tsx
+++ b/Website/src/tests/create/useCreate.test.tsx
@@ -102,9 +102,8 @@ describe("useCreate", () => {
       expect(result.current.saveDraft).toBeTypeOf("function");
     });
 
-    it("isSubmitting and isSavingDraft start as false", () => {
+    it("isSavingDraft starts as false", () => {
       const { result } = renderHook(() => useCreate(noopOnPostCreated), { wrapper: makeWrapper() });
-      expect(result.current.isSubmitting).toBe(false);
       expect(result.current.isSavingDraft).toBe(false);
     });
   });
@@ -237,32 +236,25 @@ describe("useCreate", () => {
       });
     });
 
-    it("calls onPostCreated with the published post id on success", async () => {
+    it("calls onPostCreated immediately without waiting for the API", () => {
       setupPostMock({ publishedPostId: PUBLISHED_POST_ID });
       const onPostCreated = vi.fn();
       const { result } = renderHook(() => useCreate(onPostCreated), { wrapper: makeWrapper() });
 
       act(() => result.current.handleSubmit(validValues, [makeFile()], vi.fn()));
 
-      await waitFor(() => expect(onPostCreated).toHaveBeenCalledWith(PUBLISHED_POST_ID));
+      expect(onPostCreated).toHaveBeenCalledOnce();
+      expect(onPostCreated).toHaveBeenCalledWith();
     });
 
-    it("calls handleServerError when the API fails", async () => {
+    it("fails silently when the API errors — no handleServerError called", async () => {
       mockPost.mockRejectedValueOnce(new Error("server error"));
       const { result } = renderHook(() => useCreate(noopOnPostCreated), { wrapper: makeWrapper() });
 
       act(() => result.current.handleSubmit(validValues, [makeFile()], vi.fn()));
 
-      await waitFor(() => expect(mockHandleServerError).toHaveBeenCalled());
-    });
-
-    it("calls clearServerError before submitting", async () => {
-      setupPostMock();
-      const { result } = renderHook(() => useCreate(noopOnPostCreated), { wrapper: makeWrapper() });
-
-      act(() => result.current.handleSubmit(validValues, [makeFile()], vi.fn()));
-
-      expect(mockClearServerError).toHaveBeenCalled();
+      await waitFor(() => expect(mockPost).toHaveBeenCalled());
+      expect(mockHandleServerError).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
- Fix post creation bugs and harden validation across backend, website, and mobile.
- Use `catch (Exception ex) when (ex is not OperationCanceledException)` in all service catch blocks so cancellations propagate correctly instead of being swallowed as 500s.
- Add `[MinLength]` to `Hobby` and `Title` on `CreatePostRequest` to close the gap between backend validation and the shared Zod schema.
- Add server-side per-file (50 MB) and total (100 MB) size checks to `PostHelpers.ValidateMedia`, enforced for both create and draft flows.
- Extract the draft publish field checks from `PublishDraftAsync` into `PostHelpers.ValidateDraftForPublish`.
- Update `CreatedAt` to the publish timestamp when a draft is published, so feed ordering reflects actual publish time.
- Fix `availableForTrade` in `CreateFormSchema` from `z.boolean().optional()` to `z.boolean()` to match the backend contract.
- Remove `StorePostMediaAsync` and `StorePostDetailsAsync` from `ICreatePostService` since they are implementation details, not part of the public contract.
- Make website post creation fire-and-forget: navigate to profile immediately on submit and upload in the background.
- Remove failure alerts from mobile fire-and-forget create and draft-save paths; silent failure is intentional until background service support is added.
- Preserve PNG transparency on both website and mobile by detecting PNG assets and skipping JPEG conversion.
- Fix website `useMediaUpload` to compress candidates first and size-check against compressed sizes, preventing valid files from being incorrectly rejected.
- Remove the per-file size check for images in mobile `toggleAsset` since images are compressed before upload; the limit is still enforced strictly for videos.