### PR TITLE
Added SEO metadata and robots/sitemap generation to website.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ dist/
 dist-ssr/
 *.local
 
+# Generated at build time from VITE_SITE_URL (Website/scripts/generate-seo.mjs)
+Website/public/robots.txt
+Website/public/sitemap.xml
+
 # Logs
 logs
 *.log

--- a/Website/index.html
+++ b/Website/index.html
@@ -10,12 +10,10 @@
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
     />
 
-    <title>Hobbyist</title>
-    <meta
-      name="description"
-      content="Hobbyist is a social trading platform for collectors. Share posts, list hobbies, and trade with trusted users."
-    />
-    <meta name="robots" content="index, follow" />
+    <!-- Title, description, robots and social tags are managed per-route via
+         TanStack Router's head API (see src/lib/seo.ts). This static title is
+         only a no-JS fallback for the first crawl wave. -->
+    <title>Hobbyist — Social Trading for Collectors</title>
   </head>
   <body>
     <div id="root"></div>

--- a/Website/package.json
+++ b/Website/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "node scripts/generate-seo.mjs && tsc -b && vite build",
     "preview": "vite preview --port 3001 --host",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/Website/scripts/generate-seo.mjs
+++ b/Website/scripts/generate-seo.mjs
@@ -1,0 +1,64 @@
+// Generates public/robots.txt and public/sitemap.xml from VITE_SITE_URL.
+// Runs before `vite build` (see package.json "build" script). The outputs are
+// gitignored — they are regenerated on every build from the deploy environment.
+
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const websiteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const publicDir = resolve(websiteRoot, "public");
+
+// Minimal .env reader so local `pnpm build` picks up VITE_SITE_URL without a
+// dotenv dependency. Vercel/CI supply it via process.env, which takes priority.
+function readEnvFile(name) {
+  const filePath = resolve(websiteRoot, name);
+  if (!existsSync(filePath)) return {};
+  const out = {};
+  for (const line of readFileSync(filePath, "utf8").split("\n")) {
+    const match = line.match(/^\s*([\w.]+)\s*=\s*(.*?)\s*$/);
+    if (match) out[match[1]] = match[2].replace(/^["']|["']$/g, "");
+  }
+  return out;
+}
+
+const fileEnv = { ...readEnvFile(".env"), ...readEnvFile(".env.production") };
+const siteUrl = (process.env.VITE_SITE_URL || fileEnv.VITE_SITE_URL || "").replace(/\/+$/, "");
+
+if (!siteUrl) {
+  console.warn(
+    "[generate-seo] VITE_SITE_URL is not set — writing robots.txt without a Sitemap line and skipping sitemap.xml.\n" +
+      "  Set VITE_SITE_URL to your production URL (e.g. in the Vercel project env) to enable the sitemap and canonical tags.",
+  );
+}
+
+// Public, indexable routes only. App routes behind auth are intentionally excluded.
+const routes = ["/", "/login", "/sign-up"];
+
+mkdirSync(publicDir, { recursive: true });
+
+const robots = [
+  "User-agent: *",
+  "Allow: /",
+  ...(siteUrl ? ["", `Sitemap: ${siteUrl}/sitemap.xml`] : []),
+  "",
+].join("\n");
+writeFileSync(resolve(publicDir, "robots.txt"), robots);
+console.log("[generate-seo] wrote public/robots.txt");
+
+if (siteUrl) {
+  const lastmod = new Date().toISOString().slice(0, 10);
+  const urls = routes
+    .map(
+      (route) =>
+        `  <url>\n    <loc>${siteUrl}${route}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`,
+    )
+    .join("\n");
+  const sitemap =
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+    `${urls}\n` +
+    "</urlset>\n";
+  writeFileSync(resolve(publicDir, "sitemap.xml"), sitemap);
+  console.log("[generate-seo] wrote public/sitemap.xml");
+}

--- a/Website/src/lib/seo.ts
+++ b/Website/src/lib/seo.ts
@@ -1,0 +1,53 @@
+// Builds the meta/links payload for TanStack Router's `head` route option.
+// Used together with <HeadContent /> (rendered in __root.tsx) to give each
+// route its own <title>, description, canonical URL and social tags.
+
+const SITE_NAME = "Hobbyist";
+const DEFAULT_TITLE = "Hobbyist — Social Trading for Collectors";
+const DEFAULT_DESCRIPTION =
+  "Hobbyist is a social trading platform for collectors. Share posts, list hobbies, and trade with trusted users.";
+
+// Canonical/OG URLs need an absolute origin. Prefer the build-time VITE_SITE_URL
+// (the single source of truth, also used by scripts/generate-seo.mjs); fall back
+// to the runtime origin so canonicals are still correct when the env var is unset.
+function getOrigin(): string {
+  const envUrl = import.meta.env.VITE_SITE_URL as string | undefined;
+  if (envUrl) return envUrl.replace(/\/+$/, "");
+  if (typeof window !== "undefined") return window.location.origin;
+  return "";
+}
+
+type SeoOptions = {
+  /** Page-specific title; suffixed with the site name. Omit for the site default. */
+  title?: string;
+  description?: string;
+  /** Absolute path for the canonical URL, e.g. "/login". Omit to skip canonical. */
+  path?: string;
+  /** Keep this route out of search indexes (e.g. settings, in-app screens). */
+  noindex?: boolean;
+};
+
+export function seo({ title, description, path, noindex }: SeoOptions = {}) {
+  const fullTitle = title ? `${title} · ${SITE_NAME}` : DEFAULT_TITLE;
+  const desc = description ?? DEFAULT_DESCRIPTION;
+  const origin = getOrigin();
+  const canonical = path !== undefined && origin ? `${origin}${path}` : undefined;
+
+  const meta = [
+    { title: fullTitle },
+    { name: "description", content: desc },
+    { name: "robots", content: noindex ? "noindex, nofollow" : "index, follow" },
+    { property: "og:title", content: fullTitle },
+    { property: "og:description", content: desc },
+    { property: "og:type", content: "website" },
+    { property: "og:site_name", content: SITE_NAME },
+    ...(canonical ? [{ property: "og:url", content: canonical }] : []),
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: fullTitle },
+    { name: "twitter:description", content: desc },
+  ];
+
+  const links = canonical ? [{ rel: "canonical", href: canonical }] : [];
+
+  return { meta, links };
+}

--- a/Website/src/routes/__root.tsx
+++ b/Website/src/routes/__root.tsx
@@ -1,18 +1,22 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, HeadContent, Outlet } from "@tanstack/react-router";
 import CssBaseline from "@mui/material/CssBaseline";
 
 import { CustomThemeProvider } from "@/providers/shared/CustomThemeProvider";
 import { BreakpointProvider } from "@/providers/shared/BreakpointProvider";
 import { AuthProvider } from "@/providers/app/AuthProvider";
 import { FeatureFlagsProvider } from "@/providers/root/FeatureFlagsProvider";
+import { seo } from "@/lib/seo";
 
 export const Route = createRootRoute({
+  // Site-wide defaults; individual routes override title/description via their own `head`.
+  head: () => seo(),
   component: Root,
 });
 
 function Root() {
   return (
     <CustomThemeProvider>
+      <HeadContent />
       <CssBaseline />
       <BreakpointProvider>
         <FeatureFlagsProvider>

--- a/Website/src/routes/_app/create.tsx
+++ b/Website/src/routes/_app/create.tsx
@@ -15,8 +15,10 @@ import { useCreate } from "@/hooks/create/useCreate";
 import { DesktopCreateForm } from "@/components/create/desktop/DesktopCreateForm";
 import { MobileCreateForm } from "@/components/create/mobile/MobileCreateForm";
 import { useAuth } from "@hobbyist/hooks";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_app/create")({
+  head: () => seo({ title: "Create post", noindex: true }),
   component: CreatePage,
 });
 

--- a/Website/src/routes/_app/events.tsx
+++ b/Website/src/routes/_app/events.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { FeatureGate } from "@/components/shared/FeatureGate";
 import { FeatureFlags } from "@hobbyist/types";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_app/events")({
+  head: () => seo({ title: "Events", noindex: true }),
   component: () => (
     <FeatureGate flag={FeatureFlags.Events}>
       <EventsPage />

--- a/Website/src/routes/_app/index.tsx
+++ b/Website/src/routes/_app/index.tsx
@@ -6,8 +6,15 @@ import { useAuth } from "@hobbyist/hooks";
 import { PostTile, type Post } from "@/components/home/PostTile";
 import { mockPosts } from "@/components/home/mockData";
 import { LoginSnackbar } from "@/components/home/LoginSnackbar";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_app/")({
+  head: () =>
+    seo({
+      description:
+        "Hobbyist is a social trading platform for collectors. Browse posts, discover hobbies, and trade with trusted users.",
+      path: "/",
+    }),
   component: HomePage,
 });
 

--- a/Website/src/routes/_app/messages.tsx
+++ b/Website/src/routes/_app/messages.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { FeatureGate } from "@/components/shared/FeatureGate";
 import { FeatureFlags } from "@hobbyist/types";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_app/messages")({
+  head: () => seo({ title: "Messages", noindex: true }),
   component: () => (
     <FeatureGate flag={FeatureFlags.Messages}>
       <MessagesPage />

--- a/Website/src/routes/_app/profile/$username/$postId.tsx
+++ b/Website/src/routes/_app/profile/$username/$postId.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ProfilePage } from "@/components/profile/ProfilePage";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_app/profile/$username/$postId")({
+  head: ({ params }) => seo({ title: `Post by @${params.username}`, noindex: true }),
   component: UsernamePostPage,
 });
 

--- a/Website/src/routes/_app/profile/$username/index.tsx
+++ b/Website/src/routes/_app/profile/$username/index.tsx
@@ -12,8 +12,10 @@ import { useAuth } from "@hobbyist/hooks";
 import { Header } from "@/components/profile/Header";
 import { Details } from "@/components/profile/Details";
 import { ProfileSettingsModal } from "@/components/profile/ProfileSettingsModal";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_app/profile/$username/")({
+  head: ({ params }) => seo({ title: `@${params.username}`, noindex: true }),
   component: UserProfilePage,
 });
 

--- a/Website/src/routes/_app/profile/index.tsx
+++ b/Website/src/routes/_app/profile/index.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { useAuth } from "@hobbyist/hooks";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_app/profile/")({
+  head: () => seo({ title: "Profile", noindex: true }),
   component: RouteComponent,
 });
 

--- a/Website/src/routes/_app/search.tsx
+++ b/Website/src/routes/_app/search.tsx
@@ -2,12 +2,14 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { FeatureGate } from "@/components/shared/FeatureGate";
 import { FeatureFlags } from "@hobbyist/types";
+import { seo } from "@/lib/seo";
 
 const validSearchSchema = z.object({
   q: z.string(),
 });
 
 export const Route = createFileRoute("/_app/search")({
+  head: () => seo({ title: "Search", noindex: true }),
   component: () => (
     <FeatureGate flag={FeatureFlags.Search}>
       <SearchPage />

--- a/Website/src/routes/_app/settings.tsx
+++ b/Website/src/routes/_app/settings.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+import { seo } from '@/lib/seo'
+
 export const Route = createFileRoute('/_app/settings')({
+  head: () => seo({ title: 'Settings', noindex: true }),
   component: RouteComponent,
 })
 

--- a/Website/src/routes/_app/trade.tsx
+++ b/Website/src/routes/_app/trade.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { FeatureGate } from "@/components/shared/FeatureGate";
 import { FeatureFlags } from "@hobbyist/types";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_app/trade")({
+  head: () => seo({ title: "Trade", noindex: true }),
   component: () => (
     <FeatureGate flag={FeatureFlags.Trade}>
       <TradePage />

--- a/Website/src/routes/_auth/login.tsx
+++ b/Website/src/routes/_auth/login.tsx
@@ -11,8 +11,15 @@ import { useLogin } from "@hobbyist/hooks";
 import { axiosInstance } from "@/api/axiosInstance";
 import { FormHeader } from "@/components/auth/FormHeader";
 import { FormContainer } from "@/components/auth/FormContainer";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_auth/login")({
+  head: () =>
+    seo({
+      title: "Log in",
+      description: "Log in to your Hobbyist account to post, message, and trade with other collectors.",
+      path: "/login",
+    }),
   component: Login,
 });
 

--- a/Website/src/routes/_auth/sign-up.tsx
+++ b/Website/src/routes/_auth/sign-up.tsx
@@ -14,8 +14,15 @@ import { useSignUp } from "@hobbyist/hooks";
 import { axiosInstance } from "@/api/axiosInstance";
 import { FormHeader } from "@/components/auth/FormHeader";
 import { FormContainer } from "@/components/auth/FormContainer";
+import { seo } from "@/lib/seo";
 
 export const Route = createFileRoute("/_auth/sign-up")({
+  head: () =>
+    seo({
+      title: "Sign up",
+      description: "Create a free Hobbyist account to share your collection and trade with the community.",
+      path: "/sign-up",
+    }),
   component: SignUp,
 });
 

--- a/Website/tsconfig.app.json
+++ b/Website/tsconfig.app.json
@@ -27,6 +27,7 @@
       "@/api/*": ["./src/api/*"],
       "@/components/*": ["./src/components/*"],
       "@/hooks/*": ["./src/hooks/*"],
+      "@/lib/*": ["./src/lib/*"],
       "@/providers/*": ["./src/providers/*"],
       "@/themes/*": ["./src/themes/*"]
     }


### PR DESCRIPTION
- Add per-route head tags (title, description, canonical, OG/Twitter) via the TanStack Router head API and a shared seo() helper.
- Generate robots.txt and sitemap.xml at build time from VITE_SITE_URL.
- noindex auth-gated/placeholder app routes; keep home, login and sign-up indexable.
- Remove static title/description/robots from index.html in favour of per-route head management.